### PR TITLE
Undo Annotation Scaling

### DIFF
--- a/source/server/tasks/MigratePlayTask.ts
+++ b/source/server/tasks/MigratePlayTask.ts
@@ -524,8 +524,8 @@ export default class MigratePlayTask extends Task
             annotation.color = playAnnotation["Stem.Color"];
         }
 
-        //annotation.scale = annotation.style === "Circle" ? 10 : scale;
-        annotation.scale = annotation.style === "Circle" ? 1.0 : scale;
+        annotation.scale = annotation.style === "Circle" ? 10 : scale;
+        //annotation.scale = annotation.style === "Circle" ? 1.0 : scale;
 
         annotation.position = playAnnotation["Transform.Position"];
 


### PR DESCRIPTION
- The new scaling throws things off and adds more bugs. So reverting it back.