### PR TITLE
Switch Decimation Tool to MeshLab

### DIFF
--- a/server/recipes/web-combine.json
+++ b/server/recipes/web-combine.json
@@ -98,7 +98,7 @@
                     "Meshlab",
                     "RapidCompact"
                 ],
-                "default": "RapidCompact"
+                "default": "Meshlab"
             },
             "segmentationStrengthWebThumb": {
                 "type": "number",
@@ -254,7 +254,7 @@
             "post": {
                 "remeshedFile": "deliverables.remeshedMeshFile"
             },
-            "success": "decimationTool = 'RapidCompact' ? 'decimate-rapid-webmulti' : 'decimate-meshlab-webmulti'",
+            "success": "'decimate-meshlab-webmulti'",
             "failure": "$failure"
         },
         "decimate-rapid-webthumb": {


### PR DESCRIPTION
- RapidCompact doesn't run if the input model has 150,000 faces already, so it's better to run the decimation step with MeshLab instead. This will make it so that the decimation step will always run.