### PR TITLE
Add ability to change asset quality

### DIFF
--- a/server/recipes/webasset.json
+++ b/server/recipes/webasset.json
@@ -62,6 +62,11 @@
                 "minimum": 0,
                 "default": 0
             },
+            "assetQuality": {
+                "type": "string",
+                "minLength": 1,
+                "default": "Thumb"
+            },
             "units": {
                 "type": "string",
                 "enum": [ "mm", "cm", "m", "in", "ft", "yd" ],
@@ -197,7 +202,7 @@
                 "modelIndex": "modelIndex",
                 "modelName": "baseName",
                 "units": "units",
-                "derivativeQuality": "'Thumb'",
+                "derivativeQuality": "assetQuality",
                 "modelFile": "$firstTrue(deliverables.webAssetGlb, deliverables.webAssetGltf)",
                 "numFaces": "numFaces",
                 "mapSize": "mapSize"


### PR DESCRIPTION
- Changed the hard-coded "Thumb" asset quality in webasset recipe to be user-set. The default is "Thumb" so user can ignore if that's the desired asset.